### PR TITLE
Add support for headless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,16 +132,6 @@ go func() {
 }()
 ```
 
-## Running headfull in Docker
-
-This plugin requires that you run in a headfull mode, so when using docker
-start rod with or use `XVFB()` while creating a launcher
-
-```Dockerfile
-RUN apt update && apt install -y xvfb
-CMD xvfb-run --server-args="-screen 0 1024x768x24" ./cmd-name
-```
-
 ## TODOS
  - Add test cases
  - Auto calculate stream bitrate constraints based on window dimensions 

--- a/rodstream.go
+++ b/rodstream.go
@@ -63,7 +63,7 @@ func MustPrepareLauncher(args LauncherArgs) *launcher.Launcher {
 		Set("disable-extensions-except", extPath).
 		Set("load-extension", extPath).
 		Set("allow-google-chromefile-access").
-		Headless(false)
+		Set("headless", "new")
 
 	return l
 }
@@ -96,14 +96,6 @@ func MustCreatePage(browser *rod.Browser) *PageInfo {
 		if !slices.Contains(x.Arguments, fmt.Sprintf("--whitelisted-extension-id=%s", ExtensionId)) {
 			panic("Recording extension not initialize properly!")
 		}
-	}
-
-	if slices.Contains(x.Arguments, "--headless") {
-		msg := `
-		Headless mode is not supported for rod-stream.
-		use "XVFB()" in place of "Headless(true)".
-		`
-		panic(msg)
 	}
 
 	var (


### PR DESCRIPTION
Previously, it was not possible to use headless mode as this mode did not support extensions.

With Chrome now having a **new** headless mode, this removes this limitation.

Fixes: #3