### PR TITLE
Fix deprecated whitelist extension flag

### DIFF
--- a/rodstream.go
+++ b/rodstream.go
@@ -59,7 +59,7 @@ func MustPrepareLauncher(args LauncherArgs) *launcher.Launcher {
 	l = l.
 		Set("allow-http-screen-capture").
 		Set("enable-usermedia-screen-capturing").
-		Set("whitelisted-extension-id", ExtensionId).
+		Set("allowlisted-extension-id", ExtensionId). // From Google Chrome 112.0.5615.165
 		Set("disable-extensions-except", extPath).
 		Set("load-extension", extPath).
 		Set("allow-google-chromefile-access").
@@ -93,7 +93,7 @@ func MustCreatePage(browser *rod.Browser) *PageInfo {
 	x, _ := proto.BrowserGetBrowserCommandLine{}.Call(browser)
 
 	if len(x.Arguments) > 0 {
-		if !slices.Contains(x.Arguments, fmt.Sprintf("--whitelisted-extension-id=%s", ExtensionId)) {
+		if !slices.Contains(x.Arguments, fmt.Sprintf("--load-extension=%s", extPath)) {
 			panic("Recording extension not initialize properly!")
 		}
 	}

--- a/rodstream_test.go
+++ b/rodstream_test.go
@@ -14,13 +14,18 @@ func TestMustPrepareLauncher(t *testing.T) {
 	var l = rodstream.MustPrepareLauncher(rodstream.LauncherArgs{
 		UserMode: false,
 	})
-	hasExtension := l.Flags["whitelisted-extension-id"]
 
-	if len(hasExtension) == 0 {
-		t.Error("whitelisted-extension-id is not set")
+	var extensionId []string
+
+	if value, ok := l.Flags["whitelisted-extension-id"]; ok {
+		extensionId = value
+	} else if value, ok := l.Flags["allowlisted-extension-id"]; ok {
+		extensionId = value
+	} else {
+		t.Error("Neither whitelisted-extension-id nor allowlisted-extension-id is set")
 	}
 
-	if hasExtension[0] != rodstream.ExtensionId {
+	if extensionId[0] != rodstream.ExtensionId {
 		t.Errorf("Extension is invalid")
 	}
 


### PR DESCRIPTION
Chrome has deprecated the flag `whitelisted-extension-id` and replaced it with `allowlisted-extension-id`.

This option adds the given extension ID to all the permission allowlists.

Without this setting, the recorder extension cannot be loaded.

Fixes: #2
Co-authored-by: navicstein <navicsteinrotciv@gmail.com>