### PR TITLE
Improve get stream test

### DIFF
--- a/rodstream_test.go
+++ b/rodstream_test.go
@@ -65,20 +65,32 @@ func TestMustGetStream(t *testing.T) {
 		log.Panicln(err)
 	}
 
-	time.AfterFunc(time.Second*10, func() {
-		rodstream.MustStopStream(pageInfo)
-		browser.Close()
+	time.AfterFunc(time.Minute, func() {
+		if err := rodstream.MustStopStream(pageInfo); err != nil {
+			log.Panicln(err)
+		}
+		browser.MustClose()
+		os.Exit(0)
 	})
 
-	videoFile, err := os.Create("/tmp/video-test.webm")
+	fpath := "/tmp/video-test.webm"
+	videoFile, err := os.Create(fpath)
 	if err != nil {
 		panic(err)
 	}
 
-	for x := range streamCh {
-		b := rodstream.Parseb64(x)
+	for {
+		b64Str, ok := <-streamCh
+		if !ok {
+			close(streamCh)
+			break
+		}
+
+		b := rodstream.Parseb64(b64Str)
 		videoFile.Write(b)
 	}
+
+	t.Logf("recording stopped, video available here: %s", fpath)
 }
 
 func createBrowser() *rod.Browser {


### PR DESCRIPTION
Add extra error checking when testing the `MustGetStream` function.

- Test that the stream stops successfully.
- Check that the channel has closed and end writing the file.

This also includes increasing the time before the stream must be stopped from 10 seconds to 1 minute.

The location of the video file will be shown for manual verification.