### PR TITLE
Fix test incorrectly stopping stream

### DIFF
--- a/rodstream_test.go
+++ b/rodstream_test.go
@@ -66,12 +66,12 @@ func TestMustGetStream(t *testing.T) {
 		log.Panicln(err)
 	}
 
-	time.AfterFunc(time.Minute, func() {
+	time.AfterFunc(time.Second*10, func() {
 		if err := rodstream.MustStopStream(pageInfo); err != nil {
 			log.Panicln(err)
 		}
 		browser.MustClose()
-		os.Exit(0)
+		close(streamCh)
 	})
 
 	fpath := "/tmp/video-test.webm"
@@ -83,7 +83,6 @@ func TestMustGetStream(t *testing.T) {
 	for {
 		b64Str, ok := <-streamCh
 		if !ok {
-			close(streamCh)
 			break
 		}
 


### PR DESCRIPTION
Unit tests were failing as the timer to stop the stream was incorrectly exiting. By using `os.Exit`, this caused the test to end and closed the stream channel. The loop to receive and write frames also tried to close the channel which resulted in the following error message:

```text
panic: close of closed channel [recovered]
    panic: close of closed channel
```

By closing the stream channel with the timer, there is no need to close the channel during the for loop.

The timer was previously set to 10 seconds and the last commit changed this to 1 minute. This increased the unit test time significantly and was not needed to verify recording a stream. This timer has been reset back to 10 seconds.