### PR TITLE
Improve error message when stopping recording

### DIFF
--- a/extension/recorder/background.js
+++ b/extension/recorder/background.js
@@ -109,8 +109,9 @@ function START_RECORDING(params) {
 
 function STOP_RECORDING(index) {
 	if (!recorders[index]) {
-		console.error("No recorder found for index:", index)
-		return
+		const msg = `No recorder found for index:${index}`
+		console.error(msg);
+		return window.sendError(msg)
 	};
 	recorders[index].stop();
 }


### PR DESCRIPTION
When stopping recording, any error messages were only shown on the console of the headless browser.

This change sends the error back to the Go application which allows standard error handling to apply.

Authored-by: navicstein <navicsteinrotciv@gmail.com>