### PR TITLE
Fix audio-only/video-only streaming mode

### DIFF
--- a/extension/recorder/background.js
+++ b/extension/recorder/background.js
@@ -24,17 +24,17 @@ function START_RECORDING(params) {
 		{
 			audio,
 			video,
-			audioConstraints: {
+			audioConstraints: audio ? {
 				mandatory: {
 					chromeMediaSource: 'tab',
 					echoCancellation: true
 				}
-			},
-			videoConstraints: {
+			} : undefined,
+			videoConstraints: video ? {
 				mandatory: {
 					chromeMediaSource: 'tab',
 				}
-			}
+			} : undefined
 		},
 		(stream) => {
 			try {


### PR DESCRIPTION
Hello, I really like your library, but I can't use it to capture _audio only_ (and probably _video only_) although I use the following constraints:
```go
var constraints = &rodstream.StreamConstraints{
	Audio:              true,
	Video:              false,
	MimeType:           "audio/webm",
	AudioBitsPerSecond: 48000,
	VideoBitsPerSecond: 0,
	BitsPerSecond:      8000000,
	FrameSize:          960,
}
```
```bash
> ffprobe rickroll.webm
Input #0, matroska,webm, from 'rickroll.webm':
  Metadata:
    encoder         : Chrome
  Duration: N/A, start: 0.000000, bitrate: N/A
  Stream #0:0(eng): Audio: opus, 48000 Hz, stereo, fltp (default)
  Stream #0:1(eng): Video: vp8, yuv420p(tv, bt709, progressive), 2520x1680, SAR 1:1 DAR 3:2, 1k tbr, 1k tbn (default)
      Metadata:
        alpha_mode      : 1
```
after this changes with the same constraints I get what I expect:
```bash
> ffprobe rickroll.webm
Input #0, matroska,webm, from 'rickroll.webm':
  Metadata:
    encoder         : Chrome
  Duration: N/A, start: 0.000000, bitrate: N/A
  Stream #0:0(eng): Audio: opus, 48000 Hz, stereo, fltp (default)
```